### PR TITLE
exclude license in the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+**/kendo-ui-license**
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Excluding the license in the gitignore in order to prevent someone from committing a license